### PR TITLE
fix: error handling middleware signature

### DIFF
--- a/util/error-middleware.js
+++ b/util/error-middleware.js
@@ -1,4 +1,4 @@
-async function middleware(err, req, res) {
+async function middleware(err, req, res, next) {
   console.log('ERROR', err);
   res.status(500).send({ status: 'error', reason: 'internal-error' });
 }


### PR DESCRIPTION
Error handling middleware functions must have four arguments to
identify it as such.

Fixes #40